### PR TITLE
Adding support for Models that don't have IR control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ## Status
 [![Build Status](https://travis-ci.org/koolsb/pyblackbird.svg?branch=master)](https://travis-ci.org/koolsb/pyblackbird)[![Coverage Status](https://coveralls.io/repos/github/koolsb/pyblackbird/badge.svg)](https://coveralls.io/github/koolsb/pyblackbird)
 # pyblackbird
-Python3 interface implementation for Monoprice Blackbird 4k 8x8 HDBaseT Matrix
+Python3 interface implementation for Monoprice Blackbird HDMI Matrix Switches
 
 ## Notes
 This is for use with [Home-Assistant](http://home-assistant.io)
+Has been tested with models 21819 and 24180
 
 ## Usage
 ```python
@@ -13,8 +14,14 @@ from pyblackbird import get_blackbird
 # Connect via serial port
 blackbird = get_blackbird('/dev/ttyUSB0')
 
+# Connect via serial port with a device that doesn't support IR control
+blackbird = get_blackbird('/dev/ttyUSB0', use_serial=True, ir_control=false)
+
 # Connect via IP
 blackbird = get_blackbird('192.168.1.50', use_serial=False)
+
+# Connect via IP with a device that doesn't support IR control
+blackbird = get_blackbird('192.168.1.50', use_serial=False, ir_control=false)
 
 # Print system lock status
 print('System Lock is {}'.format('On' if blackbird.lock_status() else 'Off'))

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python3 interface implementation for Monoprice Blackbird HDMI Matrix Switches
 
 ## Notes
 This is for use with [Home-Assistant](http://home-assistant.io)
-Has been tested with models 21819 and 24180
+Has been tested with models [21819](https://www.monoprice.com/product?p_id=21819) and [24180](https://www.monoprice.com/product?p_id=24180)
 
 ## Usage
 ```python


### PR DESCRIPTION
I have a model 24180.  It uses slightly different commands for control and receives a slightly different response to status requests.  I have tested these changes with my 24180 and have tried to leave the code so it will continue to work by default with the 21819.